### PR TITLE
Feature/scrum 131 delete event and tab switch lucas

### DIFF
--- a/src/app/dashboard/EventManagement/EventManagement.stories.tsx
+++ b/src/app/dashboard/EventManagement/EventManagement.stories.tsx
@@ -1,12 +1,32 @@
+import { MUIProvider } from '@/components/Providers/MUIProvider';
+import { ReduxProvider } from '@/store/provider';
+
+import React from 'react';
+
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
 import EventManagement from './EventManagement';
 
+const withAppProviders = (Story: React.ComponentType) => (
+  <ReduxProvider>
+    <MUIProvider>
+      <Story />
+    </MUIProvider>
+  </ReduxProvider>
+);
+
 const meta: Meta<typeof EventManagement> = {
   title: 'Dashboard/EventManagement/Page',
   component: EventManagement,
+  decorators: [withAppProviders],
   parameters: {
     layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'UI-only demo for Event Management — includes Delete Event (UI) and Tab Switching between Interactive Quiz / Raffle Game. Wrapped with Redux + MUI providers.',
+      },
+    },
   },
   tags: ['autodocs'],
 };

--- a/src/app/dashboard/EventManagement/EventManagement.test.tsx
+++ b/src/app/dashboard/EventManagement/EventManagement.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 
 import EventManagement from './EventManagement';
 
@@ -26,7 +26,7 @@ vi.mock('@mui/material', async importOriginal => {
   };
 });
 
-// Helper: wrap with Redux Provider
+// ✅ Helper: wrap with Redux Provider
 const renderWithRedux = (ui: React.ReactElement) => render(<Provider store={store}>{ui}</Provider>);
 
 // --- Tests ---
@@ -41,5 +41,37 @@ describe('EventManagement', () => {
     renderWithRedux(<EventManagement />);
     expect(screen.getByText('Interactive Quiz')).toBeInTheDocument();
     expect(screen.getByText('Raffle Game')).toBeInTheDocument();
+  });
+
+  it('switches tab to Raffle Game and shows empty state', () => {
+    renderWithRedux(<EventManagement />);
+    const raffleTab = screen.getByRole('button', { name: /Raffle Game/i });
+    fireEvent.click(raffleTab);
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+  });
+
+  it('deletes an event from the list (UI only)', () => {
+    renderWithRedux(<EventManagement />);
+
+    // 找到第一个卡片右上角的菜单按钮
+    const moreButtons = screen.getAllByLabelText('more actions');
+    expect(moreButtons.length).toBeGreaterThan(0);
+
+    fireEvent.click(moreButtons[0]);
+
+    // 点击 Delete 菜单项
+    const deleteItem = screen.getByText('Delete');
+    fireEvent.click(deleteItem);
+
+    // 弹出确认框
+    const dialog = screen.getByRole('dialog', { name: /Delete event/i });
+    expect(dialog).toBeInTheDocument();
+
+    // 点击 Delete 按钮确认
+    const confirmButton = within(dialog).getByRole('button', { name: /Delete/i });
+    fireEvent.click(confirmButton);
+
+    // 删除后应该显示空状态
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument();
   });
 });

--- a/src/app/dashboard/EventManagement/EventManagement.test.tsx
+++ b/src/app/dashboard/EventManagement/EventManagement.test.tsx
@@ -53,25 +53,25 @@ describe('EventManagement', () => {
   it('deletes an event from the list (UI only)', () => {
     renderWithRedux(<EventManagement />);
 
-    // 找到第一个卡片右上角的菜单按钮
+    //
     const moreButtons = screen.getAllByLabelText('more actions');
     expect(moreButtons.length).toBeGreaterThan(0);
 
     fireEvent.click(moreButtons[0]);
 
-    // 点击 Delete 菜单项
+    //  Delete
     const deleteItem = screen.getByText('Delete');
     fireEvent.click(deleteItem);
 
-    // 弹出确认框
+    //
     const dialog = screen.getByRole('dialog', { name: /Delete event/i });
     expect(dialog).toBeInTheDocument();
 
-    // 点击 Delete 按钮确认
+    //  Delete
     const confirmButton = within(dialog).getByRole('button', { name: /Delete/i });
     fireEvent.click(confirmButton);
 
-    // 删除后应该显示空状态
+    //
     expect(screen.getByTestId('empty-state')).toBeInTheDocument();
   });
 });

--- a/src/app/dashboard/EventManagement/EventManagement.tsx
+++ b/src/app/dashboard/EventManagement/EventManagement.tsx
@@ -22,10 +22,18 @@ import {
   StyledTitleBox,
 } from './EventManagement.styles';
 
+type ActiveTab = 'interactive' | 'raffle';
+
+// TODO: integrate backend when available
+async function _deleteEvent(_id: string): Promise<void> {
+  // no-op for UI-only ticket
+}
+
 export default function EventManagement() {
-  const [_activeTab, setActiveTab] = useState('interactive');
+  const [activeTab, setActiveTab] = useState<ActiveTab>('interactive');
   const [openCreateModal, setOpenCreateModal] = useState(false);
-  const [events, setEvents] = useState<EventItem[]>(initialMockEvents);
+  const [interactiveEvents, setInteractiveEvents] = useState<EventItem[]>(initialMockEvents);
+  const [raffleEvents] = useState<EventItem[]>([]);
 
   const handleInteractiveClick = useCallback(() => setActiveTab('interactive'), []);
   const handleRaffleClick = useCallback(() => setActiveTab('raffle'), []);
@@ -33,12 +41,12 @@ export default function EventManagement() {
   const handleEventCreated = (payload: CreateEventResponse) => {
     const normalized = normalizeEventPayload(payload);
     const mock = buildMockEvent(normalized);
-    setEvents(prev => [mock, ...prev]);
+    setInteractiveEvents(prev => [mock, ...prev]);
     setOpenCreateModal(false);
   };
 
   const handleEventUpdated = (updatedEvent: Event) => {
-    setEvents(prev =>
+    setInteractiveEvents(prev =>
       prev.map(event =>
         event.id === updatedEvent.id
           ? {
@@ -52,6 +60,13 @@ export default function EventManagement() {
       ),
     );
   };
+
+  const handleDelete = async (id: string) => {
+    // await deleteEvent(id); // TODO: integrate when backend is ready
+    setInteractiveEvents(prev => prev.filter(e => e.id !== id));
+  };
+
+  const currentEvents = activeTab === 'interactive' ? interactiveEvents : raffleEvents;
 
   return (
     <StyledContainer>
@@ -71,22 +86,27 @@ export default function EventManagement() {
 
       <StyledNavBox>
         <StyledNavButton
-          variant="outlined"
+          variant={activeTab === 'interactive' ? 'contained' : 'outlined'}
           startIcon={<span>💡</span>}
           onClick={handleInteractiveClick}
         >
           Interactive Quiz
         </StyledNavButton>
-        <StyledNavButton variant="outlined" startIcon={<span>🎰</span>} onClick={handleRaffleClick}>
+        <StyledNavButton
+          variant={activeTab === 'raffle' ? 'contained' : 'outlined'}
+          startIcon={<span>🎰</span>}
+          onClick={handleRaffleClick}
+        >
           Raffle Game
         </StyledNavButton>
       </StyledNavBox>
 
       <Content>
         <EventList
-          events={events}
+          events={currentEvents}
           onCreateClick={() => setOpenCreateModal(true)}
           onEventUpdated={handleEventUpdated}
+          onDelete={handleDelete}
         />
       </Content>
 

--- a/src/app/dashboard/events/components/EventCard.tsx
+++ b/src/app/dashboard/events/components/EventCard.tsx
@@ -3,7 +3,18 @@ import { Event } from '@/constants/Event';
 import React from 'react';
 
 import MoreVertIcon from '@mui/icons-material/MoreVert';
-import { Button, Chip, IconButton, Menu, MenuItem, Typography } from '@mui/material';
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Menu,
+  MenuItem,
+  Typography,
+} from '@mui/material';
 
 import EditEventModal from './EditEvent/EditEventModal';
 import {
@@ -25,9 +36,9 @@ import { AVATAR_PLACEHOLDER, COVER_PLACEHOLDER } from './eventMocks';
 type Props = {
   event: EventItem;
   onEventUpdated?: (event: Event) => void;
+  onDelete?: (id: string) => void;
 };
 
-// Convert EventItem to Event type
 const convertEventItemToEvent = (eventItem: EventItem): Event => {
   return {
     id: eventItem.id,
@@ -43,9 +54,10 @@ const convertEventItemToEvent = (eventItem: EventItem): Event => {
   };
 };
 
-export const EventCard: React.FC<Props> = ({ event, onEventUpdated }) => {
+export const EventCard: React.FC<Props> = ({ event, onEventUpdated, onDelete }) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [editModalOpen, setEditModalOpen] = React.useState(false);
+  const [deleteOpen, setDeleteOpen] = React.useState(false);
   const open = Boolean(anchorEl);
 
   const onMenuOpen = (e: React.MouseEvent<HTMLButtonElement>) => setAnchorEl(e.currentTarget);
@@ -61,6 +73,17 @@ export const EventCard: React.FC<Props> = ({ event, onEventUpdated }) => {
 
   const handleEventUpdated = (updatedEvent: Event) => {
     onEventUpdated?.(updatedEvent);
+  };
+
+  const onDeleteClick = () => {
+    setDeleteOpen(true);
+    onMenuClose();
+  };
+
+  const onConfirmDelete = async () => {
+    // TODO: integrate deleteEvent API
+    onDelete?.(event.id);
+    setDeleteOpen(false);
   };
 
   const coverSrc = event.coverImageUrl || COVER_PLACEHOLDER;
@@ -97,16 +120,30 @@ export const EventCard: React.FC<Props> = ({ event, onEventUpdated }) => {
           <Menu anchorEl={anchorEl} open={open} onClose={onMenuClose}>
             <MenuItem onClick={onMenuClose}>Rename</MenuItem>
             <MenuItem onClick={onMenuClose}>Share</MenuItem>
-            <MenuItem onClick={onMenuClose}>Delete</MenuItem>
+            <MenuItem onClick={onDeleteClick}>Delete</MenuItem>
           </Menu>
         </Actions>
       </Right>
+
       <EditEventModal
         open={editModalOpen}
         event={convertEventItemToEvent(event)}
         onClose={onEditModalClose}
         onEventUpdated={handleEventUpdated}
       />
+
+      <Dialog open={deleteOpen} onClose={() => setDeleteOpen(false)}>
+        <DialogTitle>Delete event?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">This action cannot be undone.</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteOpen(false)}>Cancel</Button>
+          <Button variant="contained" color="error" onClick={onConfirmDelete}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
     </CardRoot>
   );
 };

--- a/src/app/dashboard/events/components/EventList.tsx
+++ b/src/app/dashboard/events/components/EventList.tsx
@@ -11,9 +11,10 @@ type Props = {
   events: EventItem[];
   onCreateClick: () => void;
   onEventUpdated?: (event: Event) => void;
+  onDelete?: (id: string) => void;
 };
 
-export const EventList: React.FC<Props> = ({ events, onCreateClick, onEventUpdated }) => {
+export const EventList: React.FC<Props> = ({ events, onCreateClick, onEventUpdated, onDelete }) => {
   if (!events || events.length === 0) {
     return (
       <EmptyWrap data-testid="empty-state">
@@ -25,7 +26,7 @@ export const EventList: React.FC<Props> = ({ events, onCreateClick, onEventUpdat
   return (
     <ListRoot role="list" aria-label="event-list">
       {events.map(e => (
-        <EventCard key={e.id} event={e} onEventUpdated={onEventUpdated} />
+        <EventCard key={e.id} event={e} onEventUpdated={onEventUpdated} onDelete={onDelete} />
       ))}
     </ListRoot>
   );

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -153,7 +153,7 @@ describe('DashboardPage', () => {
     renderWithRedux(<DashboardPage />);
     const balloonImage = screen.getByAltText('Balloon');
     expect(balloonImage).toBeInTheDocument();
-    // 不再断言 src，因 getAssetUrl 可能返回 CDN 前缀
+    //  src， getAssetUrl  CDN
   });
 
   // ✅ no empty-state background anymore; we use event cover images


### PR DESCRIPTION
## 🎯 Summary
Implemented **UI-only Delete Event** and **Tab Switching** features for the Event Management page.

---

## 🧩 Scope
- Added **Delete** option to each EventCard’s “⋮ More” menu.  
  Clicking it opens a confirmation modal and removes the event (UI only).  
- Added **Interactive Quiz** / **Raffle Game** tab switching.  
  Default tab is Interactive Quiz; Raffle Game shows EmptyState.  

---

## 🧪 Tests
- Added new tests in `EventManagement.test.tsx`:
  - Renders page title and Create button  
  - Switches between tabs  
  - Deletes event and shows EmptyState  
- All tests passed (`212/212`).

---

## 🗂️ Modified Files
src/app/dashboard/EventManagement/EventManagement.tsx
src/app/dashboard/EventManagement/EventManagement.test.tsx
src/app/dashboard/EventManagement/EventManagement.stories.tsx
src/app/dashboard/events/components/EventCard.tsx
src/app/dashboard/events/components/EventList.tsx

---

## ✅ Checklist
- [x] UI and tests completed  
- [x] No API integration (UI only)  
- [x] Lint & type check passed  
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added delete action with a confirmation dialog on event cards.
  - Introduced tab-specific event views (Interactive and Raffle) with clear active-state styling.
  - Displays an empty state for the Raffle tab.

- Documentation
  - Enhanced Storybook docs and added shared app providers for the Event Management demo.

- Tests
  - Added UI tests covering tab switching and the delete flow, including confirmation.
  - Minor test comment updates for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->